### PR TITLE
Upgrade `arxiv` dependency to 1.4.1

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-arxiv==0.5.3
+arxiv==1.4.1
 certifi==2019.11.28
 chardet==3.0.4
 crossrefapi==1.4.0


### PR DESCRIPTION
## Changes

+ Pins `arxiv==1.4.1` in src/requirements.txt.
+ Simplifies arXiv result data access.
  + `(arxiv.Result).date` is a `datetime`; formats it rather than parsing.
  + Factors out `last_name` helper to simplify author string formatting.

### Testing

I added an arXiv DOI; the resulting diff seems consistent with other arXiv entries in readme.md.

```console
$ python src/doi2md.py --doi https://arxiv.org/abs/2002.11626v1 --type theory --field Science --category "Statistical reproducibility"
```

Result (`diff readme.md readme.new.md`):

```diff
2538a2539,2569
> 				<tr>
> 					<td>
> 						<p>
> 							<a href="https://arxiv.org/abs/2002.11626v1"><span title="A Realistic Guide to Making Data Available Alongside Code to Improve Reproducibility">Tierney & Ram <meta property="datePublished" content="2020-02-06">2020</span></a>
> 						</p>
> 					</td>
> 					<td>
> 						<p>
> 							<span title="Data makes science possible. Sharing data improves visibility, and makes the
> research process transparent. This increases trust in the work, and allows for
> independent reproduction of results. However, a large proportion of data from
> published research is often only available to the original authors. Despite the
> obvious benefits of sharing data, and scientists&#x27; advocating for the importance
> of sharing data, most advice on sharing data discusses its broader benefits,
> rather than the practical considerations of sharing. This paper provides
> practical, actionable advice on how to actually share data alongside research.
> The key message is sharing data falls on a continuum, and entering it should
> come with minimal barriers.">A Realistic Guide to Making Data Available Alongside Code to Improve Reproducibility</span>
> 						</p>
> 					</td>
> 					<td>
> 						<p>
> 							Science
> 						</p>
> 					</td>
> 					<td>
> 						<p>
> 							Statistical reproducibility
> 						</p>
> 					</td>
> 				</tr>
```

## Notes

I discovered https://github.com/lukasschwab/arxiv.py/issues/80 while working on this. I can update this or open a follow-up PR to narrow the exception-handling when that bug is resolved.

Feel free to treat this as really low-priority. The existing usage of the v0 client isn't *broken*, but v1 is simpler, better-typed, and easier to extend.

Hope this is helpful!