### PR TITLE
Add fairly toolset to scientific data management systems

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3555,6 +3555,7 @@ and how to make practices to achieve the highest possible reproducibility normat
 - [DVC](https://dvc.org/) - DVC tracks machine learning models and data sets
 - [DataLad](https://www.datalad.org/) - Git-based versioning for data and provenance
 - [Overture](https://www.overture.bio/) - Portal, query interface, visualization and schema framework that powers ICGC, KFDC, GDC
+- [Fairly Toolset](https://fairly.readthedocs.io) - Tools for preparing, publishing and downloading datasets from research data repositories direclty into computing environments. It provides integration with [Zenodo](https://fairly.readthedocs.io) and [Figshare](https://figshare.com/).
 
 ## Books
 - [Reproducible Research with R and R Studio 2013](https://g.co/kgs/RxcFNm)

--- a/readme.md
+++ b/readme.md
@@ -3555,7 +3555,7 @@ and how to make practices to achieve the highest possible reproducibility normat
 - [DVC](https://dvc.org/) - DVC tracks machine learning models and data sets
 - [DataLad](https://www.datalad.org/) - Git-based versioning for data and provenance
 - [Overture](https://www.overture.bio/) - Portal, query interface, visualization and schema framework that powers ICGC, KFDC, GDC
-- [Fairly Toolset](https://fairly.readthedocs.io) - Tools for preparing, publishing and downloading datasets from research data repositories direclty into computing environments. It provides integration with [Zenodo](https://fairly.readthedocs.io) and [Figshare](https://figshare.com/).
+- [Fairly Toolset](https://fairly.readthedocs.io) - Tools for preparing, publishing and downloading datasets from research data repositories directly into computing environments. It provides integration with [Zenodo](https://fairly.readthedocs.io) and [Figshare](https://figshare.com/).
 
 ## Books
 - [Reproducible Research with R and R Studio 2013](https://g.co/kgs/RxcFNm)


### PR DESCRIPTION
Include the Fairly Toolset in the list.

- It provides a workflow so that researcher can prepare datasets and metadata from the beginning of the research process. Therefore, ensuring that metadata is documented timely, and data is make ready for archiving.
- It allows users to download public datasets from Zenodo and Figshare (including their metadata) using a URL or DOI.
- Three tools are included, a Python package, a command line interface, and a JupyterLab extension.

An example of it usage is [shown here](https://fairly.readthedocs.io/en/latest/tutorials/jupyterlab.html)