### PR TITLE
Add Falsify / PRML to Scientific Data Management Systems

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4439,7 +4439,7 @@ analysis, and metabarcoding studies.">Advancing Genomic and Transcriptomic Knowl
 - [DataLad](https://www.datalad.org/) - Git-based versioning for data and provenance
 - [Overture](https://www.overture.bio/) - Portal, query interface, visualization and schema framework that powers ICGC, KFDC, GDC
 - [Fairly Toolset](https://fairly.readthedocs.io) - Tools for preparing, publishing and downloading datasets from research data repositories directly into computing environments. It provides integration with [Zenodo](https://fairly.readthedocs.io) and [Figshare](https://figshare.com/).
-
+- [Falsify / PRML](https://github.com/studio-11-co/falsify) - Pre-Registered ML Manifest specification (CC BY 4.0). SHA-256 commits an evaluation claim — metric, comparator, threshold, dataset hash, seed — before the experiment runs; forward-only `prior_hash` chain prevents silent post-hoc edits. Four reference implementations (Python, JS, Go, Rust) reproduce 20 conformance vectors byte-for-byte. DOI: 10.5281/zenodo.20177839.
 ## Books
 - [Reproducible Research with R and R Studio 2013](https://g.co/kgs/RxcFNm)
 - [Implementing Reproducible Research 2014](https://osf.io/s9tya/) - Describes projects: Sumatra, Vistrails, CDE, SOLE, JUMBO, CML, knitr. Content available on OSF.


### PR DESCRIPTION
**Adding:** PRML / Falsify — Pre-Registered ML Manifest, an open specification (CC BY 4.0) for cryptographic pre-registration of ML evaluation claims.

**Why this fits Scientific Data Management Systems:** PRML manifests are content-addressed (SHA-256 over canonical bytes) and version-controllable in the same way DataLad / DVC track data and code. The dataset hash is a required field, locking the eval to a specific dataset state at registration time. The forward-only `prior_hash` chain provides forensic provenance over the lifetime of a claim — every amendment cites its predecessor, so post-hoc threshold edits are detectable.

**What it is:** A SHA-256 manifest binds metric, comparator, threshold, dataset hash, seed, and producer identity *before* the experiment runs. The reference verifier deterministically emits PASS (exit 0), FAIL (exit 10), TAMPERED (exit 3), or GUARD (exit 11). Spec is RFC-style, ~18 pages, CC BY 4.0.

**Status:** v0.1 published, Zenodo DOI [10.5281/zenodo.20177839](https://doi.org/10.5281/zenodo.20177839). SchemaStore catalog merged. GitHub Marketplace Action live ([`prml-verify`](https://github.com/marketplace/actions/prml-verify)). Four reference implementations (Python, JavaScript, Go, Rust) all byte-equivalent on 20 conformance vectors. v0.2 RFC open through 2026-05-22.

**Maintainer:** Cüneyt Öztürk · Studio 11 — `hello@studio-11.co`