### PR TITLE
Add CiteMe to Literature tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4526,6 +4526,7 @@ analysis, and metabarcoding studies.">Advancing Genomic and Transcriptomic Knowl
     - [BILN](https://github.com/JimmyXtesla/BILN) - a lightweight, "black box" flight recorder for bioinformatics experiments
 
 ## Literature tools
+- [CiteMe](https://citeme.app) - free tool that flags fabricated or hallucinated references by verifying whether each cited work actually exists across 11+ scholarly databases; also generates and formats citations in 40+ styles, no sign-up
 - [CiteVahti](https://github.com/heidihelena/citevahti) - local-first tool that checks whether each manuscript claim is supported by its cited source, with Zotero integration and blinded human-first rating records
 - [Scite](https://scite.ai/) - Citation statement AI for discovering and evaluating scientific articles 
 - [SciScore](https://www.sciscore.com/) - SciScore methods sections for a variety of rigor criteria and analyzes sentences that contain research resources (antibodies, cell lines, plasmids and software tools) and determines how uniquely identifiable that resource is based off of the provided metadata.


### PR DESCRIPTION
Adds **CiteMe** to Literature tools, alongside CiteVahti and Scite.

**Relevance to reproducible research:** CiteMe flags **fabricated or hallucinated references** — it verifies whether each cited work actually exists across 11+ scholarly databases. As LLM-assisted writing increasingly introduces plausible-but-nonexistent citations, checking that a manuscript's references are real is a basic citation-integrity safeguard. It complements CiteVahti (which checks claim↔source support) by focusing on reference *existence*, and it's free with no sign-up.

Disclosure: I maintain CiteMe. Placed alphabetically before CiteVahti. Thanks for the list!